### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/171/045/421171045.geojson
+++ b/data/421/171/045/421171045.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13a29c804277633a9afcdedf26e3c75d",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421171045,
-    "wof:lastmodified":1566654571,
+    "wof:lastmodified":1582347106,
     "wof:name":"Agou",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/421/171/049/421171049.geojson
+++ b/data/421/171/049/421171049.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9f6362ac6dfcec59698e81443f9bd92",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421171049,
-    "wof:lastmodified":1536615924,
+    "wof:lastmodified":1582347106,
     "wof:name":"Golfe",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/421/178/017/421178017.geojson
+++ b/data/421/178/017/421178017.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009168,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7535857232e291d21f16dd41f60d90e9",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421178017,
-    "wof:lastmodified":1566654570,
+    "wof:lastmodified":1582347106,
     "wof:name":"Ogou",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/421/184/651/421184651.geojson
+++ b/data/421/184/651/421184651.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009418,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d41610020af1c7a204101bec6e2b0bd",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421184651,
-    "wof:lastmodified":1566654570,
+    "wof:lastmodified":1582347106,
     "wof:name":"Binah",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/421/187/889/421187889.geojson
+++ b/data/421/187/889/421187889.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2466b6a2e7652874e85ccbfa8d1ae7d7",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421187889,
-    "wof:lastmodified":1566654567,
+    "wof:lastmodified":1582347106,
     "wof:name":"Kozah",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/421/189/769/421189769.geojson
+++ b/data/421/189/769/421189769.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009635,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48efe27f35296e455f28ae86cb18e6eb",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":421189769,
-    "wof:lastmodified":1566654568,
+    "wof:lastmodified":1582347106,
     "wof:name":"Atakpam\u00e9",
     "wof:parent_id":421178017,
     "wof:placetype":"locality",

--- a/data/421/191/833/421191833.geojson
+++ b/data/421/191/833/421191833.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009711,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c036adec017cbb4e4d6263e70cf74672",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421191833,
-    "wof:lastmodified":1566654569,
+    "wof:lastmodified":1582347106,
     "wof:name":"Kpendjal",
     "wof:parent_id":85678549,
     "wof:placetype":"county",

--- a/data/421/198/915/421198915.geojson
+++ b/data/421/198/915/421198915.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459009965,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbe6e233c9bc314db5ab5415abcfc0eb",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421198915,
-    "wof:lastmodified":1566654568,
+    "wof:lastmodified":1582347106,
     "wof:name":"Lacs",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/421/199/773/421199773.geojson
+++ b/data/421/199/773/421199773.geojson
@@ -542,6 +542,9 @@
     },
     "wof:country":"TG",
     "wof:created":1459010000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f30a9b0f4d399cb1e537caec886a571",
     "wof:hierarchy":[
         {
@@ -560,7 +563,7 @@
         }
     ],
     "wof:id":421199773,
-    "wof:lastmodified":1566654569,
+    "wof:lastmodified":1582347106,
     "wof:name":"Lom\u00e9",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/856/326/47/85632647.geojson
+++ b/data/856/326/47/85632647.geojson
@@ -891,6 +891,11 @@
     },
     "wof:country":"TG",
     "wof:country_alpha3":"TGO",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"7cf9d426abac5e47c65c89f6aa48e2a3",
     "wof:hierarchy":[
         {
@@ -905,7 +910,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654311,
+    "wof:lastmodified":1582347102,
     "wof:name":"Togo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/785/31/85678531.geojson
+++ b/data/856/785/31/85678531.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Plateaux Region, Togo"
     },
     "wof:country":"TG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4de963e8fbe199a64830e0bf8febd383",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654310,
+    "wof:lastmodified":1582347101,
     "wof:name":"Plateaux",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/37/85678537.geojson
+++ b/data/856/785/37/85678537.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Maritime Region"
     },
     "wof:country":"TG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe0a001e2903ddfd5779809ddb824ab5",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654310,
+    "wof:lastmodified":1582347101,
     "wof:name":"Maritime",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/41/85678541.geojson
+++ b/data/856/785/41/85678541.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Kara Region"
     },
     "wof:country":"TG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60c4320467eb57b7b0cf7fec41e5f4b6",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654310,
+    "wof:lastmodified":1582347101,
     "wof:name":"Kara",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/45/85678545.geojson
+++ b/data/856/785/45/85678545.geojson
@@ -280,6 +280,9 @@
         "wd:id":"Q316220"
     },
     "wof:country":"TG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e024a535062db52e880805f6c12b8662",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654310,
+    "wof:lastmodified":1582347101,
     "wof:name":"Centre",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/49/85678549.geojson
+++ b/data/856/785/49/85678549.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Savanes Region, Togo"
     },
     "wof:country":"TG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"441ea699077d84157a61b610f3826d9e",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566654311,
+    "wof:lastmodified":1582347101,
     "wof:name":"Savanes",
     "wof:parent_id":85632647,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.