### PR TITLE
tg concordances, placetype local, and more

### DIFF
--- a/data/110/856/115/7/1108561157.geojson
+++ b/data/110/856/115/7/1108561157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117505,
-    "geom:area_square_m":1426580244.156599,
+    "geom:area_square_m":1426580505.861879,
     "geom:bbox":"-0.145744,10.757029,0.423496,11.138991",
     "geom:latitude":10.936802,
     "geom:longitude":0.168094,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"TG.SA.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981949,
-    "wof:geomhash":"c5519a0e8635cec6abbac9ce49f614e4",
+    "wof:geomhash":"8fe32e8f9ce6869864edcb5bcef5db4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108561157,
-    "wof:lastmodified":1636501344,
+    "wof:lastmodified":1695886776,
     "wof:name":"Tone",
     "wof:parent_id":85678549,
     "wof:placetype":"county",

--- a/data/110/856/115/9/1108561159.geojson
+++ b/data/110/856/115/9/1108561159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096425,
-    "geom:area_square_m":1171737464.906783,
+    "geom:area_square_m":1171737420.03949,
     "geom:bbox":"-0.090052,10.399133,0.352852,10.813052",
     "geom:latitude":10.658365,
     "geom:longitude":0.145531,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TG.SA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981952,
-    "wof:geomhash":"38b90e0f9b2590c30efde8050e3e41bb",
+    "wof:geomhash":"d571d50d3593f428b4b157e5f4241532",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108561159,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Tandjouare",
     "wof:parent_id":85678549,
     "wof:placetype":"county",

--- a/data/110/856/116/1/1108561161.geojson
+++ b/data/110/856/116/1/1108561161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.353138,
-    "geom:area_square_m":4295445192.538896,
+    "geom:area_square_m":4295444928.755015,
     "geom:bbox":"0.218038,9.888401,0.922007,10.735034",
     "geom:latitude":10.356748,
     "geom:longitude":0.561727,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"TG.SA.OT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981953,
-    "wof:geomhash":"0cfdcb55fb89ea765f09c2b7c3329f06",
+    "wof:geomhash":"58fad36ee47cd79fda58a09161c47614",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108561161,
-    "wof:lastmodified":1636501343,
+    "wof:lastmodified":1695886776,
     "wof:name":"Oti",
     "wof:parent_id":85678549,
     "wof:placetype":"county",

--- a/data/110/856/116/3/1108561163.geojson
+++ b/data/110/856/116/3/1108561163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145246,
-    "geom:area_square_m":1768509424.538431,
+    "geom:area_square_m":1768510102.091696,
     "geom:bbox":"0.658559,9.853147,1.284381,10.275833",
     "geom:latitude":10.036687,
     "geom:longitude":0.925659,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"TG.KA.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981955,
-    "wof:geomhash":"5901974da0cfe8235e9d69645a865cf2",
+    "wof:geomhash":"623c123ecf6f36946801231b4ce9e0e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108561163,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Keran",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/110/856/116/5/1108561165.geojson
+++ b/data/110/856/116/5/1108561165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103347,
-    "geom:area_square_m":1259152542.877879,
+    "geom:area_square_m":1259153064.794508,
     "geom:bbox":"0.835442,9.634634,1.335239,10.041859",
     "geom:latitude":9.826394,
     "geom:longitude":1.08176,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"TG.KA.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981956,
-    "wof:geomhash":"0087b4e6310a045b2ced2e45a4ce8251",
+    "wof:geomhash":"3d947878a4a9429cfd40bf701c681eef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561165,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Doufelgou",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/110/856/116/9/1108561169.geojson
+++ b/data/110/856/116/9/1108561169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222129,
-    "geom:area_square_m":2707376933.883069,
+    "geom:area_square_m":2707376642.527771,
     "geom:bbox":"0.225446,9.410031,0.878408,10.040103",
     "geom:latitude":9.702594,
     "geom:longitude":0.551203,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.KA.DP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981958,
-    "wof:geomhash":"ff0ccb89a4ecd24a93ae5b4fb49628e9",
+    "wof:geomhash":"e0a0be46165e0e922d7a030cafae8f36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561169,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Dankpen",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/110/856/117/1/1108561171.geojson
+++ b/data/110/856/117/1/1108561171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.269589,
-    "geom:area_square_m":3289960547.46079,
+    "geom:area_square_m":3289960437.525876,
     "geom:bbox":"0.455754,8.865409,1.028226,9.677487",
     "geom:latitude":9.271478,
     "geom:longitude":0.757116,
@@ -142,9 +142,10 @@
     "wof:concordances":{
         "hasc:id":"TG.KA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981961,
-    "wof:geomhash":"8c22f3236989f2dee26514d6109befee",
+    "wof:geomhash":"3663fe3d70ff04d1f31e6f5b3df589e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108561171,
-    "wof:lastmodified":1636501344,
+    "wof:lastmodified":1695886776,
     "wof:name":"Bassar",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/110/856/117/3/1108561173.geojson
+++ b/data/110/856/117/3/1108561173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070639,
-    "geom:area_square_m":861873498.280604,
+    "geom:area_square_m":861873330.242223,
     "geom:bbox":"0.935574,9.21296,1.424441,9.463872",
     "geom:latitude":9.344504,
     "geom:longitude":1.195542,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"TG.KA.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981962,
-    "wof:geomhash":"aacb2f7fd5734863ea9478fc4f752242",
+    "wof:geomhash":"cc12efbe3bb135890e6e3bd050bb1758",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561173,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886515,
     "wof:name":"Assoli",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/110/856/117/5/1108561175.geojson
+++ b/data/110/856/117/5/1108561175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217016,
-    "geom:area_square_m":2650356972.602986,
+    "geom:area_square_m":2650356737.750966,
     "geom:bbox":"0.882138,8.668261,1.45694,9.307277",
     "geom:latitude":9.006002,
     "geom:longitude":1.171813,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.CE.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981964,
-    "wof:geomhash":"77adfc44ca04310b32138c6f78bb9808",
+    "wof:geomhash":"b50e74849b2a87bc560a86e0a143c551",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561175,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Tchaoudjo",
     "wof:parent_id":85678545,
     "wof:placetype":"county",

--- a/data/110/856/117/7/1108561177.geojson
+++ b/data/110/856/117/7/1108561177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256166,
-    "geom:area_square_m":3130817434.546216,
+    "geom:area_square_m":3130817434.54621,
     "geom:bbox":"1.2273215867,8.36207737279,1.64750605602,9.26852831601",
     "geom:latitude":8.730001,
     "geom:longitude":1.46128,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"TG.CE.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981965,
-    "wof:geomhash":"385d29b2c2e7ca48852e0f34f5e9d097",
+    "wof:geomhash":"f952f7b3e6653861afabfc0d50874edc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108561177,
-    "wof:lastmodified":1566654499,
+    "wof:lastmodified":1695886487,
     "wof:name":"Tchamba",
     "wof:parent_id":85678545,
     "wof:placetype":"county",

--- a/data/110/856/117/9/1108561179.geojson
+++ b/data/110/856/117/9/1108561179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.369323,
-    "geom:area_square_m":4514616982.220353,
+    "geom:area_square_m":4514616999.971951,
     "geom:bbox":"0.374531,8.352649,1.270393,9.066696",
     "geom:latitude":8.664105,
     "geom:longitude":0.834623,
@@ -145,9 +145,10 @@
     "wof:concordances":{
         "hasc:id":"TG.CE.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981966,
-    "wof:geomhash":"fb90209e8aad1f0ec75333f82ba3b88d",
+    "wof:geomhash":"eee901c9dd6120df334e582151cd9916",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108561179,
-    "wof:lastmodified":1636501343,
+    "wof:lastmodified":1695886776,
     "wof:name":"Sotouboua",
     "wof:parent_id":85678545,
     "wof:placetype":"county",

--- a/data/110/856/118/1/1108561181.geojson
+++ b/data/110/856/118/1/1108561181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26156,
-    "geom:area_square_m":3201467277.07465,
+    "geom:area_square_m":3201466794.103067,
     "geom:bbox":"0.587245,7.901825,1.27365,8.407664",
     "geom:latitude":8.163148,
     "geom:longitude":0.931665,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.CE.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981968,
-    "wof:geomhash":"f42cf85ad731ffeace93078308f44bd8",
+    "wof:geomhash":"986539d7925f08a229f63cb48d12c1e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561181,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886515,
     "wof:name":"Blitta",
     "wof:parent_id":85678545,
     "wof:placetype":"county",

--- a/data/110/856/118/3/1108561183.geojson
+++ b/data/110/856/118/3/1108561183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203126,
-    "geom:area_square_m":2486663442.176366,
+    "geom:area_square_m":2486663480.446677,
     "geom:bbox":"1.150681,7.771914,1.632135,8.368938",
     "geom:latitude":8.094688,
     "geom:longitude":1.422701,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981969,
-    "wof:geomhash":"62bb8b8870afd64608dad2e09a29d928",
+    "wof:geomhash":"9c344e2255bbfb90b24a888f14e82026",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561183,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Est-Mono",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/118/7/1108561187.geojson
+++ b/data/110/856/118/7/1108561187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199118,
-    "geom:area_square_m":2440090704.240642,
+    "geom:area_square_m":2440090537.487193,
     "geom:bbox":"0.514356,7.370864,1.078881,7.985507",
     "geom:latitude":7.670985,
     "geom:longitude":0.763283,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.WW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981971,
-    "wof:geomhash":"00cfd8ce229ca29b0a46bab5daad7444",
+    "wof:geomhash":"a12c153ed5701fd4323ef9d08d5c6c74",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108561187,
-    "wof:lastmodified":1636501343,
+    "wof:lastmodified":1695886776,
     "wof:name":"Wawa",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/118/9/1108561189.geojson
+++ b/data/110/856/118/9/1108561189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141972,
-    "geom:area_square_m":1740332914.948723,
+    "geom:area_square_m":1740332914.948724,
     "geom:bbox":"0.783842464782,7.1883748655,1.15583823059,7.87176479847",
     "geom:latitude":7.539295,
     "geom:longitude":1.002108,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981973,
-    "wof:geomhash":"eadd7cf0501c17480dfabe3632373e70",
+    "wof:geomhash":"b0b3068c764325b462ed8aef725657da",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108561189,
-    "wof:lastmodified":1566654497,
+    "wof:lastmodified":1695886486,
     "wof:name":"Amou",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/119/1/1108561191.geojson
+++ b/data/110/856/119/1/1108561191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048118,
-    "geom:area_square_m":590308482.214425,
+    "geom:area_square_m":590308945.093422,
     "geom:bbox":"1.444286,7.001075,1.634039,7.403221",
     "geom:latitude":7.194113,
     "geom:longitude":1.560524,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981975,
-    "wof:geomhash":"16d1ded953d6df17e81ff07a843f55ae",
+    "wof:geomhash":"981f4b7a127dcf5d5f1106f7396a0507",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561191,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Moyen-Mono",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/119/3/1108561193.geojson
+++ b/data/110/856/119/3/1108561193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160271,
-    "geom:area_square_m":1966642562.825451,
+    "geom:area_square_m":1966642887.830021,
     "geom:bbox":"0.520573,6.751821,0.98749,7.395925",
     "geom:latitude":7.085831,
     "geom:longitude":0.749029,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.DY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981976,
-    "wof:geomhash":"be9b6e18459376250edc5732fea31140",
+    "wof:geomhash":"e8bbbdacf5a648a05417c414279701e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561193,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Kloto",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/119/5/1108561195.geojson
+++ b/data/110/856/119/5/1108561195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243953,
-    "geom:area_square_m":2993913136.023101,
+    "geom:area_square_m":2993912543.195632,
     "geom:bbox":"0.912388,6.734659,1.583439,7.299382",
     "geom:latitude":7.01985,
     "geom:longitude":1.233772,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"TG.PL.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981978,
-    "wof:geomhash":"ac5e8377e2d07127c93c6791b15cac9c",
+    "wof:geomhash":"09ac01a454b6d22f483004ee342f3d35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561195,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Haho",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/110/856/119/7/1108561197.geojson
+++ b/data/110/856/119/7/1108561197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103469,
-    "geom:area_square_m":1270688396.742877,
+    "geom:area_square_m":1270688617.692192,
     "geom:bbox":"1.232932,6.446622,1.654888,6.911498",
     "geom:latitude":6.697089,
     "geom:longitude":1.446715,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"TG.MA.YO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981980,
-    "wof:geomhash":"222093dcdf5f46b8b262a68aac3f3433",
+    "wof:geomhash":"73678430d0c7f14724b56b95c3cf6903",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561197,
-    "wof:lastmodified":1627522815,
+    "wof:lastmodified":1695886517,
     "wof:name":"Yoto",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/110/856/119/9/1108561199.geojson
+++ b/data/110/856/119/9/1108561199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263941,
-    "geom:area_square_m":3242613549.396563,
+    "geom:area_square_m":3242613720.882065,
     "geom:bbox":"0.719042,6.179174,1.392977,6.832288",
     "geom:latitude":6.511318,
     "geom:longitude":1.086948,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"TG.MA.ZI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981982,
-    "wof:geomhash":"0b3eb776e364b34264e8d2d7712c9408",
+    "wof:geomhash":"05d983fbdc57133797314f7965b17441",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108561199,
-    "wof:lastmodified":1627522815,
+    "wof:lastmodified":1695886517,
     "wof:name":"Zio",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/110/856/120/1/1108561201.geojson
+++ b/data/110/856/120/1/1108561201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060788,
-    "geom:area_square_m":746996532.244913,
+    "geom:area_square_m":746996202.766798,
     "geom:bbox":"1.367189,6.219334,1.607767,6.565158",
     "geom:latitude":6.385391,
     "geom:longitude":1.485114,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"TG.MA.VO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1473981984,
-    "wof:geomhash":"8c9d504d33ee696fd4987b94562e523b",
+    "wof:geomhash":"b680d61d4a8e1943b57bbf1701eb4696",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561201,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886516,
     "wof:name":"Vo",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/117/561/366/7/1175613667.geojson
+++ b/data/117/561/366/7/1175613667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029111,
-    "geom:area_square_m":357856740.024858,
+    "geom:area_square_m":357856763.198842,
     "geom:bbox":"1.083806,6.103445,1.387521,6.306257",
     "geom:latitude":6.20375,
     "geom:longitude":1.207245,
@@ -118,9 +118,10 @@
         "wd:id":"Q3910168",
         "wk:page":"Golfe Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459008879,
-    "wof:geomhash":"e669de2e89af6803aa1c809b51cabfaf",
+    "wof:geomhash":"a85c64fb83be78fed1b7366922149a7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1175613667,
-    "wof:lastmodified":1690868600,
+    "wof:lastmodified":1695886487,
     "wof:name":"Golfe",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/421/171/045/421171045.geojson
+++ b/data/421/171/045/421171045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080759,
-    "geom:area_square_m":991668124.11349,
+    "geom:area_square_m":991668011.476453,
     "geom:bbox":"0.619828,6.52301,0.922757,6.933659",
     "geom:latitude":6.753499,
     "geom:longitude":0.77816,
@@ -112,12 +112,13 @@
         "wd:id":"Q3408917",
         "wk:page":"Kloto Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23ee48a919e160fc8b3a7a304763e1f5",
+    "wof:geomhash":"7395d38c246c3ba637bb9c0351b49405",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421171045,
-    "wof:lastmodified":1690868603,
+    "wof:lastmodified":1695886514,
     "wof:name":"Agou",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/421/178/017/421178017.geojson
+++ b/data/421/178/017/421178017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313706,
-    "geom:area_square_m":3845189959.115273,
+    "geom:area_square_m":3845189143.726773,
     "geom:bbox":"1.035646,7.168864,1.646739,7.975738",
     "geom:latitude":7.572773,
     "geom:longitude":1.35298,
@@ -94,12 +94,13 @@
         "hasc:id":"TG.PL.OU",
         "qs_pg:id":22077
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459009168,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"320bd53d2efbc58d90d516799af37bca",
+    "wof:geomhash":"9dba16fb2b4dfe3e32dcb50408f10d93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421178017,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Ogou",
     "wof:parent_id":85678531,
     "wof:placetype":"county",

--- a/data/421/184/651/421184651.geojson
+++ b/data/421/184/651/421184651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046444,
-    "geom:area_square_m":566021256.364771,
+    "geom:area_square_m":566020683.874791,
     "geom:bbox":"1.195704,9.4233,1.400508,10.011878",
     "geom:latitude":9.732245,
     "geom:longitude":1.310856,
@@ -96,12 +96,13 @@
         "hasc:id":"TG.KA.BI",
         "qs_pg:id":1002806
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459009418,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bfea08be593d1036b652558d15c33eab",
+    "wof:geomhash":"6ff6094c6c4853487afb2ef3448d9aef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":421184651,
-    "wof:lastmodified":1627522813,
+    "wof:lastmodified":1695886514,
     "wof:name":"Binah",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/421/187/889/421187889.geojson
+++ b/data/421/187/889/421187889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087901,
-    "geom:area_square_m":1071854012.409312,
+    "geom:area_square_m":1071854269.592956,
     "geom:bbox":"0.917212,9.374588,1.363518,9.756333",
     "geom:latitude":9.550076,
     "geom:longitude":1.146597,
@@ -95,12 +95,13 @@
         "hasc:id":"TG.KA.KO",
         "qs_pg:id":9288
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b478b8b7b466fccbb7199cbb0dcc51c",
+    "wof:geomhash":"419aa524ce5135784b17cf8d931e5151",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421187889,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Kozah",
     "wof:parent_id":85678541,
     "wof:placetype":"county",

--- a/data/421/191/833/421191833.geojson
+++ b/data/421/191/833/421191833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144215,
-    "geom:area_square_m":1751357307.294145,
+    "geom:area_square_m":1751357469.835419,
     "geom:bbox":"0.307522,10.686444,0.912797,11.026387",
     "geom:latitude":10.850688,
     "geom:longitude":0.613603,
@@ -95,12 +95,13 @@
         "hasc:id":"TG.SA.KP",
         "qs_pg:id":119969
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459009711,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eb385292ff7d5f9588c1a31077e70e32",
+    "wof:geomhash":"6fd8033a19e22d622b80c500312a2bff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421191833,
-    "wof:lastmodified":1627522814,
+    "wof:lastmodified":1695886515,
     "wof:name":"Kpendjal",
     "wof:parent_id":85678549,
     "wof:placetype":"county",

--- a/data/421/198/915/421198915.geojson
+++ b/data/421/198/915/421198915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066548,
-    "geom:area_square_m":817777470.441725,
+    "geom:area_square_m":817778009.062666,
     "geom:bbox":"1.382006,6.171069,1.803364,6.583679",
     "geom:latitude":6.383736,
     "geom:longitude":1.640427,
@@ -133,12 +133,13 @@
         "wd:id":"Q3910174",
         "wk:page":"Lacs Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TG",
     "wof:created":1459009965,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"982e125f228feb30350b7b23b471d4cb",
+    "wof:geomhash":"004a9eef547fe85edba455d1f386cddc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421198915,
-    "wof:lastmodified":1690868602,
+    "wof:lastmodified":1695886776,
     "wof:name":"Lacs",
     "wof:parent_id":85678537,
     "wof:placetype":"county",

--- a/data/856/326/47/85632647.geojson
+++ b/data/856/326/47/85632647.geojson
@@ -1050,6 +1050,7 @@
         "hasc:id":"TG",
         "icao:code":"5V",
         "ioc:id":"TOG",
+        "iso:code":"TG",
         "itu:id":"TGO",
         "loc:id":"n80061115",
         "m49:code":"768",
@@ -1064,6 +1065,7 @@
         "wk:page":"Togo",
         "wmo:id":"TG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:country_alpha3":"TGO",
     "wof:geom_alt":[
@@ -1085,7 +1087,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639532,
+    "wof:lastmodified":1695881189,
     "wof:name":"Togo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/785/31/85678531.geojson
+++ b/data/856/785/31/85678531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.391025,
-    "geom:area_square_m":17054809325.657476,
+    "geom:area_square_m":17054808842.226364,
     "geom:bbox":"0.514356,6.52301,1.646739,8.368938",
     "geom:latitude":7.445891,
     "geom:longitude":1.126253,
@@ -283,17 +283,19 @@
         "gn:id":2364370,
         "gp:id":56048438,
         "hasc:id":"TG.PL",
+        "iso:code":"TG-P",
         "iso:id":"TG-P",
         "qs_pg:id":1206064,
         "unlc:id":"TG-P",
         "wd:id":"Q316306",
         "wk:page":"Plateaux Region, Togo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4264c495bb505390e3202139c1850a4f",
+    "wof:geomhash":"977f20eb6a4795ed15dfbee0f1f83a14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -308,7 +310,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690868597,
+    "wof:lastmodified":1695884883,
     "wof:name":"Plateaux",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/37/85678537.geojson
+++ b/data/856/785/37/85678537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.523858,
-    "geom:area_square_m":6435932688.85092,
+    "geom:area_square_m":6435933313.602593,
     "geom:bbox":"0.719042,6.103445,1.803364,6.911498",
     "geom:latitude":6.500099,
     "geom:longitude":1.281206,
@@ -298,17 +298,19 @@
         "gn:id":2365173,
         "gp:id":56048437,
         "hasc:id":"TG.MA",
+        "iso:code":"TG-M",
         "iso:id":"TG-M",
         "qs_pg:id":1206055,
         "unlc:id":"TG-M",
         "wd:id":"Q316291",
         "wk:page":"Maritime Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"585886ee36e5094ee366b94ae37e95ba",
+    "wof:geomhash":"64e47c200f4fb61627632757af5160cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690868597,
+    "wof:lastmodified":1695884883,
     "wof:name":"Maritime",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/41/85678541.geojson
+++ b/data/856/785/41/85678541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.945296,
-    "geom:area_square_m":11524748215.814899,
+    "geom:area_square_m":11524748530.649841,
     "geom:bbox":"0.225446,8.865409,1.424441,10.275833",
     "geom:latitude":9.605028,
     "geom:longitude":0.866305,
@@ -282,17 +282,19 @@
         "gn:id":2597439,
         "gp:id":56048435,
         "hasc:id":"TG.KA",
+        "iso:code":"TG-K",
         "iso:id":"TG-K",
         "qs_pg:id":1105217,
         "unlc:id":"TG-K",
         "wd:id":"Q316216",
         "wk:page":"Kara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e211a259fefa21f8441cdef373152c2",
+    "wof:geomhash":"9322bdbe5a1db08dd53d05434d1e6a98",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690868598,
+    "wof:lastmodified":1695884883,
     "wof:name":"Kara",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/45/85678545.geojson
+++ b/data/856/785/45/85678545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.104065,
-    "geom:area_square_m":13497258666.444201,
+    "geom:area_square_m":13497258736.993359,
     "geom:bbox":"0.374531,7.901825,1.647506,9.307277",
     "geom:latitude":8.627918,
     "geom:longitude":1.069289,
@@ -286,16 +286,18 @@
         "gn:id":2367237,
         "gp:id":56048436,
         "hasc:id":"TG.CE",
+        "iso:code":"TG-C",
         "iso:id":"TG-C",
         "qs_pg:id":483102,
         "unlc:id":"TG-C",
         "wd:id":"Q316220"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db211b481d23d964ce55030aedb83d58",
+    "wof:geomhash":"f651232baa0fbecf681e633f4b876f8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690868597,
+    "wof:lastmodified":1695884883,
     "wof:name":"Centre",
     "wof:parent_id":85632647,
     "wof:placetype":"region",

--- a/data/856/785/49/85678549.geojson
+++ b/data/856/785/49/85678549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711282,
-    "geom:area_square_m":8645120208.89642,
+    "geom:area_square_m":8645120324.491814,
     "geom:bbox":"-0.145744,9.888401,0.922007,11.138991",
     "geom:latitude":10.59361,
     "geom:longitude":0.450795,
@@ -279,16 +279,18 @@
         "gn:id":2364205,
         "gp:id":56048434,
         "hasc:id":"TG.SA",
+        "iso:code":"TG-S",
         "iso:id":"TG-S",
         "qs_pg:id":1105216,
         "wd:id":"Q279945",
         "wk:page":"Savanes Region, Togo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TG",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"433ce91815f8f1e8c55604490e7bfd58",
+    "wof:geomhash":"b94974f0b80533b27f970c0e7b9c4c46",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690868598,
+    "wof:lastmodified":1695884883,
     "wof:name":"Savanes",
     "wof:parent_id":85632647,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.